### PR TITLE
RIS-20: Timestamp precision and local env setup

### DIFF
--- a/app/(protected)/run-data/page.tsx
+++ b/app/(protected)/run-data/page.tsx
@@ -51,7 +51,7 @@ function formatReportingMonthYear(ym: string | null | undefined): string {
   return date.toLocaleDateString("en-GB", { month: "long", year: "numeric" });
 }
 
-/** Format ISO timestamp for Run Metadata: "15 Mar 2026 — 09:08". */
+/** Format ISO timestamp for Run Metadata: "15 Mar 2026 — 09:08:37". */
 function formatRunTimestamp(iso: string): string {
   try {
     const d = new Date(iso);
@@ -64,6 +64,7 @@ function formatRunTimestamp(iso: string): string {
     const timePart = d.toLocaleTimeString("en-GB", {
       hour: "2-digit",
       minute: "2-digit",
+      second: "2-digit",
       hour12: false,
     });
     return `${datePart} — ${timePart}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update Run Data timestamp formatter to include seconds (`HH:MM:SS`)
- keep existing date/time style and layout unchanged
- apply consistently to Run Metadata timestamp fields that use `formatRunTimestamp` (Run timestamp, Locked on)

## Testing
- `npx eslint "app/(protected)/run-data/page.tsx"` (passes; warnings only)
- `npm run lint` (fails due pre-existing repo-wide lint errors unrelated to this change)
- `npm run build` (fails due missing env vars in cloud environment: `NEXT_PUBLIC_SUPABASE_URL`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [RIS-20](https://linear.app/riskai-mvp/issue/RIS-20/add-seconds-to-timestamp-on-run-data-page)

<div><a href="https://cursor.com/agents/bc-0969dd1f-899b-4b22-8602-be4a55679cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0969dd1f-899b-4b22-8602-be4a55679cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

