### PR TITLE
RIS-32: Save and display reporting lock using authenticated UUID

### DIFF
--- a/app/(protected)/run-data/page.tsx
+++ b/app/(protected)/run-data/page.tsx
@@ -49,10 +49,12 @@ function formatCost(value: number): string {
   }).format(value);
 }
 
-/** Format reporting_month_year (YYYY-MM) as "March 2025". */
-function formatReportingMonthYear(ym: string | null | undefined): string {
-  if (!ym || !/^\d{4}-\d{2}$/.test(ym)) return "—";
-  const [y, m] = ym.split("-").map(Number);
+/** Format report month (YYYY-MM or YYYY-MM-DD) as "March 2025". */
+function formatReportingMonthYear(value: string | null | undefined): string {
+  const normalized = value?.trim();
+  if (!normalized || !/^\d{4}-\d{2}(-\d{2})?$/.test(normalized)) return "—";
+  const yearMonth = normalized.slice(0, 7);
+  const [y, m] = yearMonth.split("-").map(Number);
   const date = new Date(y, m - 1, 1);
   return date.toLocaleDateString("en-GB", { month: "long", year: "numeric" });
 }
@@ -158,6 +160,14 @@ export default function RunDataPage({ projectId, projectName }: RunDataPageProps
       .catch(() => setReportingSnapshotRow(null));
   }, [projectId, current?.id, isCurrentRunPersisted]);
   const reportingDbRow = reportingSnapshotRow as SimulationSnapshotRowDb | null;
+  const isReportingVersion = Boolean(
+    reportingDbRow?.locked_for_reporting ?? reportingDbRow?.reporting_version
+  );
+  const reportingMonthValue =
+    reportingDbRow?.report_month ?? reportingDbRow?.reporting_month_year ?? null;
+  const lockedByValue = reportingDbRow?.locked_by ?? reportingDbRow?.reporting_locked_by ?? null;
+  const lockedAtValue = reportingDbRow?.locked_at ?? reportingDbRow?.reporting_locked_at ?? null;
+  const lockNoteValue = reportingDbRow?.lock_note ?? reportingDbRow?.reporting_note ?? null;
   const momentumSummary = useMemo(() => portfolioMomentumSummary(risks), [risks]);
 
   /** Neutral baseline snapshot: always used for Project Cost block so project cost is scenario-invariant. */
@@ -1036,7 +1046,7 @@ export default function RunDataPage({ projectId, projectName }: RunDataPageProps
                     <div>
                       <dt className="text-neutral-500 dark:text-neutral-400 font-normal">Reporting version</dt>
                       <dd className="mt-0.5">
-                        {reportingDbRow?.reporting_version ? (
+                        {isReportingVersion ? (
                           <span className="inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200">
                             Yes
                           </span>
@@ -1062,8 +1072,8 @@ export default function RunDataPage({ projectId, projectName }: RunDataPageProps
                     <div>
                       <dt className="text-neutral-500 dark:text-neutral-400 font-normal">Reporting month / year</dt>
                       <dd className="mt-0.5 text-neutral-800 dark:text-neutral-200">
-                        {reportingDbRow?.reporting_month_year ? (
-                          formatReportingMonthYear(reportingDbRow.reporting_month_year)
+                        {reportingMonthValue ? (
+                          formatReportingMonthYear(reportingMonthValue)
                         ) : (
                           <span className="text-neutral-500 dark:text-neutral-400">Not set</span>
                         )}
@@ -1072,7 +1082,7 @@ export default function RunDataPage({ projectId, projectName }: RunDataPageProps
                     <div>
                       <dt className="text-neutral-500 dark:text-neutral-400 font-normal">Locked by</dt>
                       <dd className="mt-0.5 text-neutral-800 dark:text-neutral-200">
-                        {reportingDbRow?.reporting_locked_by?.trim() || (
+                        {(typeof lockedByValue === "string" ? lockedByValue.trim() : lockedByValue) || (
                           <span className="text-neutral-500 dark:text-neutral-400">Not set</span>
                         )}
                       </dd>
@@ -1080,8 +1090,8 @@ export default function RunDataPage({ projectId, projectName }: RunDataPageProps
                     <div>
                       <dt className="text-neutral-500 dark:text-neutral-400 font-normal">Locked on</dt>
                       <dd className="mt-0.5 text-neutral-800 dark:text-neutral-200">
-                        {reportingDbRow?.reporting_locked_at ? (
-                          formatRunTimestamp(reportingDbRow.reporting_locked_at)
+                        {lockedAtValue ? (
+                          formatRunTimestamp(lockedAtValue)
                         ) : (
                           <span className="text-neutral-500 dark:text-neutral-400">Not set</span>
                         )}
@@ -1090,7 +1100,7 @@ export default function RunDataPage({ projectId, projectName }: RunDataPageProps
                     <div>
                       <dt className="text-neutral-500 dark:text-neutral-400 font-normal">Reporting note</dt>
                       <dd className="mt-0.5 text-neutral-800 dark:text-neutral-200">
-                        {reportingDbRow?.reporting_note?.trim() || (
+                        {(typeof lockNoteValue === "string" ? lockNoteValue.trim() : lockNoteValue) || (
                           <span className="text-neutral-500 dark:text-neutral-400">Not available</span>
                         )}
                       </dd>

--- a/app/(protected)/simulation/SimulationPageContent.tsx
+++ b/app/(protected)/simulation/SimulationPageContent.tsx
@@ -696,20 +696,41 @@ export default function SimulationPage({ projectId: urlProjectId }: SimulationPa
                 onClick={async () => {
                   const currentId = simulation.current?.id;
                   if (!currentId || !effectiveProjectId || !currentUserId) return;
+                  console.info("[simulation] set reporting version click", {
+                    snapshot_id: currentId,
+                    project_id: effectiveProjectId,
+                    locked_for_reporting: true,
+                    locked_at: new Date().toISOString(),
+                    locked_by: currentUserId,
+                    lock_note: reportingNote.trim() || null,
+                    report_month: `${reportingMonthYear}-01`,
+                  });
                   setSetReportingSaving(true);
                   try {
-                    await setSnapshotAsReportingVersion(currentId, {
+                    const updatedRow = await setSnapshotAsReportingVersion(currentId, {
+                      projectId: effectiveProjectId,
                       note: reportingNote,
                       lockedByUserId: currentUserId,
                       reportingMonthYear,
                     });
+                    console.info("[simulation] reporting lock persisted", {
+                      snapshot_id: currentId,
+                      project_id: effectiveProjectId,
+                      response_row: updatedRow,
+                    });
                     const row = await getLatestSnapshot(effectiveProjectId);
-                    if (row?.id === currentId) setReportingSnapshotRow(row);
+                    console.info("[simulation] latest snapshot after lock", {
+                      snapshot_id: row?.id ?? null,
+                      project_id: effectiveProjectId,
+                    });
+                    if (row?.id === currentId) {
+                      setReportingSnapshotRow(row);
+                    } else {
+                      setReportingSnapshotRow(updatedRow);
+                    }
                     setSetReportingModalOpen(false);
                     setReportingNote("");
                     setReportingMonthYear(toMonthYearKey(new Date()));
-                  } catch {
-                    // Error already logged in setSnapshotAsReportingVersion
                   } finally {
                     setSetReportingSaving(false);
                   }

--- a/app/(protected)/simulation/SimulationPageContent.tsx
+++ b/app/(protected)/simulation/SimulationPageContent.tsx
@@ -272,6 +272,9 @@ export default function SimulationPage({ projectId: urlProjectId }: SimulationPa
       })
       .catch(() => setReportingSnapshotRow(null));
   }, [effectiveProjectId, persistedRunId]);
+  const isReportingVersionLocked = Boolean(
+    reportingDbRow?.locked_for_reporting ?? reportingDbRow?.reporting_version
+  );
 
   const analysisState = useMemo(
     () => ({ risks, simulation: { ...simulation } }),
@@ -442,7 +445,7 @@ export default function SimulationPage({ projectId: urlProjectId }: SimulationPa
         {showResults &&
           isCurrentRunPersisted &&
           effectiveProjectId &&
-          !reportingDbRow?.reporting_version && (
+          !isReportingVersionLocked && (
           <button
             type="button"
             onClick={() => !simulationReadOnly && setSetReportingModalOpen(true)}

--- a/app/(protected)/simulation/SimulationPageContent.tsx
+++ b/app/(protected)/simulation/SimulationPageContent.tsx
@@ -154,6 +154,7 @@ export default function SimulationPage({ projectId: urlProjectId }: SimulationPa
   const [reportingNote, setReportingNote] = useState("");
   const [reportingMonthYear, setReportingMonthYear] = useState(() => toMonthYearKey(new Date()));
   const [setReportingSaving, setSetReportingSaving] = useState(false);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [triggeredBy, setTriggeredBy] = useState<string | null>(null);
 
   const reportingMonthYearOptions = useMemo(() => getReportingMonthYearOptions(), []);
@@ -174,13 +175,18 @@ export default function SimulationPage({ projectId: urlProjectId }: SimulationPa
       .getUser()
       .then(async ({ data: { user } }) => {
         if (!user) {
+          setCurrentUserId(null);
           setTriggeredBy(null);
           return;
         }
+        setCurrentUserId(user.id);
         const profile = await fetchPublicProfile(supabase, user.id);
         setTriggeredBy(formatTriggeredByLabel(user, profile));
       })
-      .catch(() => setTriggeredBy(null));
+      .catch(() => {
+        setCurrentUserId(null);
+        setTriggeredBy(null);
+      });
   }, []);
   const setupRedirectPath = urlProjectId ? `/projects/${urlProjectId}` : "/";
 
@@ -683,15 +689,15 @@ export default function SimulationPage({ projectId: urlProjectId }: SimulationPa
               </button>
               <button
                 type="button"
-                disabled={setReportingSaving}
+                disabled={setReportingSaving || !currentUserId}
                 onClick={async () => {
                   const currentId = simulation.current?.id;
-                  if (!currentId || !effectiveProjectId) return;
+                  if (!currentId || !effectiveProjectId || !currentUserId) return;
                   setSetReportingSaving(true);
                   try {
                     await setSnapshotAsReportingVersion(currentId, {
                       note: reportingNote,
-                      lockedBy: triggeredBy ?? "Unknown",
+                      lockedByUserId: currentUserId,
                       reportingMonthYear,
                     });
                     const row = await getLatestSnapshot(effectiveProjectId);

--- a/src/lib/db/snapshots.ts
+++ b/src/lib/db/snapshots.ts
@@ -191,12 +191,38 @@ export type SimulationSnapshotRow = {
  * Base shape is {@link SimulationSnapshotRow}; this type is for typed access only.
  */
 export type SimulationSnapshotRowDb = NonNullable<SimulationSnapshotRow> & {
+  // Preferred lock fields.
+  locked_for_reporting?: boolean;
+  locked_at?: string | null;
+  locked_by?: string | null;
+  lock_note?: string | null;
+  report_month?: string | null;
+  // Legacy lock fields.
   reporting_version?: boolean;
   reporting_locked_at?: string | null;
   reporting_locked_by?: string | null;
   reporting_note?: string | null;
   reporting_month_year?: string | null;
 };
+
+/** Convert YYYY-MM to YYYY-MM-01 for date-backed report_month column. */
+function toReportMonthDate(reportingMonthYear: string): string | null {
+  const ym = reportingMonthYear?.trim();
+  if (!ym || !/^\d{4}-\d{2}$/.test(ym)) return null;
+  return `${ym}-01`;
+}
+
+/** True when update failed because payload columns are not present in this schema. */
+function isMissingColumnError(error: unknown): boolean {
+  const maybe = error as { code?: string; message?: string } | null;
+  const code = maybe?.code ?? "";
+  const message = maybe?.message ?? "";
+  return (
+    code === "PGRST204" ||
+    /column .* does not exist/i.test(message) ||
+    /could not find .* in the schema cache/i.test(message)
+  );
+}
 
 /**
  * Set a snapshot as the reporting version (one-way lock). Persists reporting_version, locked_at, locked_by, note, reporting_month_year.
@@ -212,16 +238,35 @@ export async function setSnapshotAsReportingVersion(
   }
 
   const supabase = supabaseBrowserClient();
-  const { error } = await supabase
+  const lockedAt = new Date().toISOString();
+  const reportMonthDate = toReportMonthDate(params.reportingMonthYear);
+  const lockNote = params.note?.trim() || null;
+
+  // Preferred schema: locked_for_reporting, locked_at, locked_by, lock_note, report_month.
+  let { error } = await supabase
     .from("riskai_simulation_snapshots")
     .update({
-      reporting_version: true,
-      reporting_locked_at: new Date().toISOString(),
-      reporting_locked_by: lockedByUserId,
-      reporting_note: params.note?.trim() || null,
-      reporting_month_year: params.reportingMonthYear?.trim() || null,
+      locked_for_reporting: true,
+      locked_at: lockedAt,
+      locked_by: lockedByUserId,
+      lock_note: lockNote,
+      report_month: reportMonthDate,
     })
     .eq("id", snapshotId);
+
+  // Backward compatibility for older environments still on reporting_* fields.
+  if (error && isMissingColumnError(error)) {
+    ({ error } = await supabase
+      .from("riskai_simulation_snapshots")
+      .update({
+        reporting_version: true,
+        reporting_locked_at: lockedAt,
+        reporting_locked_by: lockedByUserId,
+        reporting_note: lockNote,
+        reporting_month_year: params.reportingMonthYear?.trim() || null,
+      })
+      .eq("id", snapshotId));
+  }
 
   if (error) {
     console.error("[setSnapshotAsReportingVersion]", error);

--- a/src/lib/db/snapshots.ts
+++ b/src/lib/db/snapshots.ts
@@ -204,15 +204,20 @@ export type SimulationSnapshotRowDb = NonNullable<SimulationSnapshotRow> & {
  */
 export async function setSnapshotAsReportingVersion(
   snapshotId: string,
-  params: { note: string; lockedBy: string; reportingMonthYear: string }
+  params: { note: string; lockedByUserId: string; reportingMonthYear: string }
 ): Promise<void> {
+  const lockedByUserId = params.lockedByUserId?.trim();
+  if (!lockedByUserId) {
+    throw new Error("Cannot lock reporting snapshot without an authenticated user ID.");
+  }
+
   const supabase = supabaseBrowserClient();
   const { error } = await supabase
     .from("riskai_simulation_snapshots")
     .update({
       reporting_version: true,
       reporting_locked_at: new Date().toISOString(),
-      reporting_locked_by: params.lockedBy || null,
+      reporting_locked_by: lockedByUserId,
       reporting_note: params.note?.trim() || null,
       reporting_month_year: params.reportingMonthYear?.trim() || null,
     })

--- a/src/lib/db/snapshots.ts
+++ b/src/lib/db/snapshots.ts
@@ -231,8 +231,17 @@ function isMissingColumnError(error: unknown): boolean {
  */
 export async function setSnapshotAsReportingVersion(
   snapshotId: string,
-  params: { note: string; lockedByUserId: string; reportingMonthYear: string }
-): Promise<void> {
+  params: {
+    projectId: string;
+    note: string;
+    lockedByUserId: string;
+    reportingMonthYear: string;
+  }
+): Promise<SimulationSnapshotRowDb> {
+  const projectId = params.projectId?.trim();
+  if (!projectId) {
+    throw new Error("Cannot lock reporting snapshot without a project ID.");
+  }
   const lockedByUserId = params.lockedByUserId?.trim();
   if (!lockedByUserId) {
     throw new Error("Cannot lock reporting snapshot without an authenticated user ID.");
@@ -241,36 +250,94 @@ export async function setSnapshotAsReportingVersion(
   const supabase = supabaseBrowserClient();
   const lockedAt = new Date().toISOString();
   const reportMonthDate = toReportMonthDate(params.reportingMonthYear);
+  if (!reportMonthDate) {
+    throw new Error(
+      `Invalid reportingMonthYear '${params.reportingMonthYear}'. Expected format YYYY-MM.`
+    );
+  }
   const lockNote = params.note?.trim() || null;
+  const selector = { snapshotId, projectId };
+  const preferredPayload = {
+    locked_for_reporting: true,
+    locked_at: lockedAt,
+    locked_by: lockedByUserId,
+    lock_note: lockNote,
+    report_month: reportMonthDate,
+  };
+  console.info("[setSnapshotAsReportingVersion] input", {
+    snapshot_id: snapshotId,
+    project_id: projectId,
+    ...preferredPayload,
+  });
+  console.info("[setSnapshotAsReportingVersion] selector", selector);
+  console.info("[setSnapshotAsReportingVersion] payload", preferredPayload);
 
   // Preferred schema: locked_for_reporting, locked_at, locked_by, lock_note, report_month.
-  let { error } = await supabase
+  let {
+    data,
+    error,
+    status,
+    statusText,
+  } = await supabase
     .from("riskai_simulation_snapshots")
-    .update({
-      locked_for_reporting: true,
-      locked_at: lockedAt,
-      locked_by: lockedByUserId,
-      lock_note: lockNote,
-      report_month: reportMonthDate,
-    })
-    .eq("id", snapshotId);
+    .update(preferredPayload)
+    .eq("id", snapshotId)
+    .eq("project_id", projectId)
+    .select("id, project_id, locked_for_reporting, locked_at, locked_by, lock_note, report_month");
+  console.info("[setSnapshotAsReportingVersion] response (preferred)", {
+    status,
+    statusText,
+    error,
+    data,
+  });
 
   // Backward compatibility for older environments still on reporting_* fields.
   if (error && isMissingColumnError(error)) {
-    ({ error } = await supabase
+    const legacyPayload = {
+      reporting_version: true,
+      reporting_locked_at: lockedAt,
+      reporting_locked_by: lockedByUserId,
+      reporting_note: lockNote,
+      reporting_month_year: params.reportingMonthYear?.trim() || null,
+    };
+    console.info("[setSnapshotAsReportingVersion] payload (legacy fallback)", legacyPayload);
+    ({
+      data,
+      error,
+      status,
+      statusText,
+    } = await supabase
       .from("riskai_simulation_snapshots")
-      .update({
-        reporting_version: true,
-        reporting_locked_at: lockedAt,
-        reporting_locked_by: lockedByUserId,
-        reporting_note: lockNote,
-        reporting_month_year: params.reportingMonthYear?.trim() || null,
-      })
-      .eq("id", snapshotId));
+      .update(legacyPayload)
+      .eq("id", snapshotId)
+      .eq("project_id", projectId)
+      .select(
+        "id, project_id, reporting_version, reporting_locked_at, reporting_locked_by, reporting_note, reporting_month_year"
+      ));
+    console.info("[setSnapshotAsReportingVersion] response (legacy fallback)", {
+      status,
+      statusText,
+      error,
+      data,
+    });
   }
 
   if (error) {
     console.error("[setSnapshotAsReportingVersion]", error);
     throw error;
   }
+
+  const updatedRow = data?.[0] as SimulationSnapshotRowDb | undefined;
+  if (!updatedRow) {
+    const noRowError = new Error(
+      "Reporting lock update completed without returning an affected row."
+    );
+    console.error("[setSnapshotAsReportingVersion] no affected row", {
+      selector,
+      preferredPayload,
+    });
+    throw noRowError;
+  }
+
+  return updatedRow;
 }

--- a/src/lib/db/snapshots.ts
+++ b/src/lib/db/snapshots.ts
@@ -225,8 +225,9 @@ function isMissingColumnError(error: unknown): boolean {
 }
 
 /**
- * Set a snapshot as the reporting version (one-way lock). Persists reporting_version, locked_at, locked_by, note, reporting_month_year.
- * reporting_month_year should be "YYYY-MM" (e.g. "2025-03").
+ * Set a snapshot as the reporting version (one-way lock).
+ * Prefers locked_* columns and falls back to legacy reporting_* columns when required.
+ * reportingMonthYear should be "YYYY-MM" (e.g. "2025-03").
  */
 export async function setSnapshotAsReportingVersion(
   snapshotId: string,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fixed reporting lock writes to prefer the current `locked_*` schema (`locked_for_reporting`, `locked_at`, `locked_by`, `lock_note`, `report_month`)
- kept backward compatibility by falling back to legacy `reporting_*` columns only when newer columns are unavailable
- updated Simulation page lock-status checks to recognize both new and legacy lock flags
- updated Run Data audit panel to read/report both new and legacy lock fields, so saved lock state renders correctly
- preserved UUID-based `locked_by` behavior (`user.id`) from the previous fix
- clarified helper docs/comments to reflect schema fallback behavior

## Validation
- `npm run lint -- src/lib/db/snapshots.ts "app/(protected)/simulation/SimulationPageContent.tsx" "app/(protected)/run-data/page.tsx"` (passes with pre-existing warnings in run-data hook deps)

## Notes
- no schema changes
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [RIS-32](https://linear.app/riskai-mvp/issue/RIS-32/implement-project-overview-page-from-latest-locked-reporting-run-and)

<div><a href="https://cursor.com/agents/bc-fa5efbab-cc5e-45b0-aefe-938f850304fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa5efbab-cc5e-45b0-aefe-938f850304fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

